### PR TITLE
Add include traversing methods to ApiResource

### DIFF
--- a/src/Http/Resources/TransformRelationToResource.php
+++ b/src/Http/Resources/TransformRelationToResource.php
@@ -14,8 +14,8 @@ trait TransformRelationToResource
 {
     use GuessForModel;
 
-    private ApiResource $parentResource;
-    private string $requestedAs;
+    private ?ApiResource $parentResource = null;
+    private ?string $requestedAs = null;
 
     /**
      * Override the mapping of a Model with its Resource

--- a/src/Http/Resources/TransformRelationToResource.php
+++ b/src/Http/Resources/TransformRelationToResource.php
@@ -46,10 +46,10 @@ trait TransformRelationToResource
     /**
      * Transform a relation with its own related resource class
      *
-     * @param string $relation
+     * @param Model|Collection $relation
      * @return ApiResource|ResourceCollection|mixed
      */
-    protected function transformRelation(string $relation)
+    protected function transformRelation($relation)
     {
         if(empty($relation)) {
             return $relation;

--- a/src/Services/QueryBuilder/ApiIncludes.php
+++ b/src/Services/QueryBuilder/ApiIncludes.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Cronqvist\Api\Services\QueryBuilder;
+
+use Cronqvist\Api\Services\QueryBuilder\Includes\IncludedDummy;
+use Illuminate\Support\Collection;
+use Spatie\QueryBuilder\AllowedInclude;
+
+class ApiIncludes extends AllowedInclude
+{
+
+    public static function dummy(string $name, $internalName = null): Collection
+    {
+        return collect([
+            new static($name, new IncludedDummy(), $internalName),
+        ]);
+    }
+}

--- a/src/Services/QueryBuilder/Includes/IncludedDummy.php
+++ b/src/Services/QueryBuilder/Includes/IncludedDummy.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Cronqvist\Api\Services\QueryBuilder\Includes;
+
+use Illuminate\Database\Eloquent\Builder;
+use Spatie\QueryBuilder\Includes\IncludeInterface;
+
+class IncludedDummy implements IncludeInterface
+{
+    public function __invoke(Builder $query, string $include)
+    {
+
+    }
+}


### PR DESCRIPTION
Sample usage:

```

class UserController extends ApiController
{

    protected function getBuilder()
    {
        return QueryBuilder::for(User::class)
            ->allowedIncludes([
                ApiIncludes::dummy('foo'),
            ])
        ;
    }
}


class UserResource extends ApiResource
{
    public function toArray($request)
    {
        return [
            'userid' => $this->userid,
            'bar'    => $this->whenIncluded('foo', fn() => 'baz!')
        ];
    }
}
```

```
GET /v3/api/users?include=foo

{"data":[{"userid":1149920,"bar":"baz!"},{"userid":1149921,"bar":"baz!"},{"userid":1149922,"bar":"baz!"}, ...
```