### PR TITLE
Preserve query parameters in pagination links

### DIFF
--- a/src/Http/Controllers/ApiController.php
+++ b/src/Http/Controllers/ApiController.php
@@ -103,7 +103,8 @@ abstract class ApiController extends BaseController
                 : $builder->get();
 
             if($data instanceof AbstractPaginator) {
-                $data = $data->setCollection($this->transformData($data->getCollection()));
+                $data = $data->setCollection($this->transformData($data->getCollection()))
+                             ->withQueryString();
             } else {
                 $data = $this->transformData($data);
             }


### PR DESCRIPTION
For example, changes in bold
`GET /v3/api/users?include=country`
<pre>{
  "data": [],
  "links": {
    "first": "/v3/api/users?<b>include=country&</b>page=1",
    "last": "/v3/api/users?<b>include=country&</b>page=1",
    "prev": null,
    "next": null
  },
  "meta": {
    "current_page": 1,
    "from": 1,
    "last_page": 39,
    "links": [
      {
        "url": null,
        "label": "pagination.previous",
        "active": false
      },
      {
        "url": "/v3/api/users?<b>include=country&</b>page=1",
        "label": "1",
        "active": true
      {
        "url": null,
        "label": "pagination.next",
        "active": false
      }
    ],
    "path": "/v3/api/users",
    "per_page": 100,
    "to": 100,
    "total": 100
  }
}</pre>